### PR TITLE
Adding support for neo4j-extensions-parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,13 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.neo4j</groupId>
+    <parent>
+        <groupId>org.neo4j</groupId>
+        <artifactId>neo4j-extensions-parent</artifactId>
+        <version>3.1.1.0-SNAPSHOT</version>
+        <relativePath>../neo4j-extensions-dependencies-parent/parent/pom.xml</relativePath>
+    </parent>
+
     <artifactId>neo4j-graphql</artifactId>
     <version>1.0-SNAPSHOT</version>
 
@@ -17,8 +23,6 @@
     </licenses>
 
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>1.8</java.version>
         <kotlin.version>1.0.5-eap-66</kotlin.version>
     </properties>
 
@@ -44,39 +48,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.neo4j</groupId>
-            <artifactId>neo4j</artifactId>
-            <version>3.0.6</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.neo4j.test</groupId>
-            <artifactId>neo4j-harness</artifactId>
-            <version>3.0.6</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.neo4j</groupId>
-            <artifactId>server-api</artifactId>
-            <version>3.0.6</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
-            <version>1.9.13</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>com.graphql-java</groupId>
             <artifactId>graphql-java</artifactId>
             <version>2.1.0</version>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
@@ -181,8 +155,8 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
+                    <source>${version.java}</source>
+                    <target>${version.java}</target>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
This is for 3.1 support right now. We can make a branch for 3.0 support as well. Should just need to switch over to the 3.0 neo4j-extensions-parent.