### PR TITLE
support filtering on absent relations using "null" keyword, fixes #101

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -506,7 +506,7 @@ query PersonQuery {
 
 | filter arguments for relations
 | filtering on relation fields, suffixes ("",not,some, none, single, every)
-| { Company(filter: { employees_none { name_contains: "Jan"}, employees_some: { gender_in : [female]}}) { name } }
+| { Company(filter: { employees_none { name_contains: "Jan"}, employees_some: { gender_in : [female]}, company_not: null }) { name } }
 
 | relationships
 | via a `@relationship` annotated field, optional direction

--- a/src/main/kotlin/org/neo4j/graphql/GraphQLExtensions.kt
+++ b/src/main/kotlin/org/neo4j/graphql/GraphQLExtensions.kt
@@ -15,9 +15,13 @@ fun Value.extract(): Any =
             is EnumValue -> this.name
             is VariableReference -> "{`${this.name}`}" // todo $name
             is ArrayValue -> this.values.map { it.extract() }.toList()
+            is NullValue -> IsNullOperator()
             else -> throw IllegalArgumentException("Unknown Value $this ${this.javaClass}")
         }
 fun Field.cypher() = this.getDirective("cypher")?.let { Pair(it.getArgument("statement").value.extract(), it.getArgument("params")?.value?.extract()) }
+
+abstract class UnaryOperator
+class IsNullOperator : UnaryOperator()
 
 data class CypherDefinition(val statement:String, val  params:Map<String,Any>? = emptyMap(), val passThrough:Boolean = false)
 fun FieldDefinition.cypher() : CypherDefinition ?=

--- a/src/test/java/org/neo4j/graphql/FilterTest.kt
+++ b/src/test/java/org/neo4j/graphql/FilterTest.kt
@@ -110,6 +110,12 @@ type Company {
         assertResult("""{ p: Company { employees(filter: { OR: [{ name: "Jane" },{name:"Joe"}]}) { name }}}""", mapOf("p" to listOf(mapOf("employees" to listOf(mapOf("name" to "Joe"), mapOf("name" to "Jane"))))))
     }
     @Test
+    fun filtersOnNullField() {
+        db?.execute("MATCH (p:Person { id: 'joe'})-[r:WORKS_AT]-(:Company) DELETE r")?.close()
+        assertResult("{ p: Person(filter: { company: null }) { name }}", joe)
+        assertResult("{ p: Person(filter: { company_not: null }) { name }}", jane)
+    }
+    @Test
     fun stringFilter() {
         assertFilter("name: \"Jane\"", "Jane")
         assertFilter("name_starts_with: \"Ja\"", "Jane")


### PR DESCRIPTION
Sometimes we are fetching data with absent relations, this PR adds the ability to include or exclude results for which some relations are missing
In a nutshell, we now transform `Node(filter: { field: null })` to `WHERE NOT (node)-[:field]->()`
and `Node(filter_not: { field: null })` to `WHERE (node)-[:field]->()`