### PR TITLE
adding `graphql.getIdl()` 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.neo4j</groupId>
     <artifactId>neo4j-graphql</artifactId>
-    <version>3.4.0.0</version>
+    <version>3.4.0.2-SNAPSHOT</version>
 
     <licenses>
         <license>
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
         <kotlin.version>1.1.51</kotlin.version>
-        <neo4j.version>3.4.0</neo4j.version>
+        <neo4j.version>3.4.9</neo4j.version>
     </properties>
 
     <organization>

--- a/readme.adoc
+++ b/readme.adoc
@@ -107,6 +107,14 @@ To visualize your GraphQL schema in Neo4j Browser use: `call graphql.schema()`.
 
 image::{img}/graphql.schema.jpg[width=600]
 
+Using
+
+----
+RETURN graphql.getIdl()
+----
+
+you'll get back a string representation of the currently used schema.
+
 === Auto-Generated Query Types
 
 From that schema, the plugin automatically generate *Query Types* for each of the declared types.

--- a/src/main/kotlin/org/neo4j/graphql/GraphQLProcedure.kt
+++ b/src/main/kotlin/org/neo4j/graphql/GraphQLProcedure.kt
@@ -1,6 +1,7 @@
 package org.neo4j.graphql
 
 import graphql.ExecutionInput
+import graphql.schema.idl.SchemaPrinter
 import org.neo4j.graphdb.GraphDatabaseService
 import org.neo4j.graphdb.Node
 import org.neo4j.graphdb.Relationship
@@ -65,6 +66,12 @@ class GraphQLProcedure {
             val storeIdl = GraphSchemaScanner.storeIdl(db!!, idl)
             return Stream.of(StringResult(storeIdl.toString()))
         }
+    }
+
+    @UserFunction( "graphql.getIdl")
+    fun getIdl() : String {
+        val schema = GraphQLSchemaBuilder.buildSchema(db!!)
+        return SchemaPrinter().print(schema)
     }
 
     @Procedure("graphql.schema")

--- a/src/test/java/org/neo4j/graphql/GraphQLResourceTest.java
+++ b/src/test/java/org/neo4j/graphql/GraphQLResourceTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import org.neo4j.graphdb.*;
 import org.neo4j.harness.ServerControls;
 import org.neo4j.harness.TestServerBuilders;
+import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.test.server.HTTP;
 
 import java.net.URL;
@@ -139,6 +140,12 @@ public class GraphQLResourceTest {
                 "RETURN labels(`Person`) AS `_labels`,\n" +
                 "`Person` {.`name`, .`born`} AS `row`";
         testCypherCall(call);
+    }
+
+    @Test
+    public void testGetIdl() {
+        String idl = Iterators.single(neo4j.graph().execute("return graphql.getIdl() as schema").columnAs("schema"));
+        assertEquals(4164, idl.length());
     }
 
     private void testCypherCall(String call) {


### PR DESCRIPTION
a new user function to return a string representation of the currently used schema.

This is useful e.g. if you want to start with a auto-inferred schema defintion and later on you want to enrich it e.g. using custom cypher queries.