### PR TITLE
fix apparent typo on readme

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -48,7 +48,7 @@ To generate some graph data in Neo4j just run http://localhost:7474/browser?cmd=
 
 The best tool to use is https://electronjs.org/apps/graphiql[GraphiQL^] the GraphQL UI. Get and install it.
 
-Enter your GraphQL URL, like `http://localhost:7474/graphql/` (_note the trailing slash_).
+Enter your GraphQL URL, like `+http://localhost:7474/graphql/+` (_note the trailing slash_).
 
 If your Neo4j Server runs with *authentication enabled*, add the appropriate Basic-Auth (https://www.base64encode.org/[base64 encoded^]) `username:password` header in the "Edit HTTP Headers" screen.
 


### PR DESCRIPTION
I saw this on the [Quickstart](https://github.com/neo4j-graphql/neo4j-graphql#graphiql) and thought it was a potentially confusing typo: 
 
- ![image](https://user-images.githubusercontent.com/8560265/51273662-4c2aa800-199b-11e9-9688-1d6b947a0150.png)

Turns out it's not a typo - it's Github deciding to display the URL as a hyperlink and stripping the trailing slash. Wrapping the URL in [a literal](https://github.com/neo4j-graphql/neo4j-graphql#graphiql) fixes this by preventing  it from being displayed as a link (which is arguably better anyway).   

![image](https://user-images.githubusercontent.com/8560265/51274273-bd1e8f80-199c-11e9-975f-c43c25ed543d.png)

 